### PR TITLE
Factbird mini 1.0 based on embedded-nal v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+...
+
+## [0.2.0] - 2020-12-02
+
 ### Added
 - Added a new `UdpServer` trait with server-specific methods
 - Added a new `TcpServer` trait with server-specific methods
@@ -26,5 +30,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release to crates.io.
 
-[Unreleased]: https://github.com/rust-embedded-community/embedded-nal/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/rust-embedded-community/embedded-nal/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/rust-embedded-community/embedded-nal/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/rust-embedded-community/embedded-nal/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Ability to specify a local UDP port
+- Added a new `UdpServer` trait with server-specific methods
 ### Changed
 - Changed the `UdpStack::receive` method to return the packet sender address, along with the packet length
+- Changed the name of `UdpStack` to `UdpClient`
 ### Removed
 - Removed `Mode` enum, implementations should instead use `nb::WouldBlock`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Changed the `UdpStack::receive` method to return the packet sender address, along with the packet length
+### Removed
+- Removed `Mode` enum, implementations should instead use `nb::WouldBlock`
 
 ## [0.1.0] - 2020-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Ability to specify a local UDP port
 ### Changed
 - Changed the `UdpStack::receive` method to return the packet sender address, along with the packet length
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Added a new `UdpServer` trait with server-specific methods
+- Added a new `TcpServer` trait with server-specific methods
+
 ### Changed
 - Changed the `UdpStack::receive` method to return the packet sender address, along with the packet length
 - Changed the name of `UdpStack` to `UdpClient`
+- Changed name of `TcpStack` to `TcpClient`
+- Changed the `TcpCStack::connect()` function to return an `nb::Result`
+- Renamed `open()` functions to `socket()` for both stacks
+- Renamed `read()` and `write()` functions to `send()` and `receive()` respectively
+- Updated `UdpStack::connect()` to modify an existing socket
+
 ### Removed
 - Removed `Mode` enum, implementations should instead use `nb::WouldBlock`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-...
+### Changed
+- Changed the `UdpStack::receive` method to return the packet sender address, along with the packet length
 
 ## [0.1.0] - 2020-08-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "embedded-nal"
-version = "0.1.0"
+version = "0.2.0" # remember to update html_root_url
 authors = [
     "Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
     "Mathias Koch <mk@blackbird.online>",
     "Diego Barrios Romero <eldruin@gmail.com>",
+    "Ryan Summers <ryan.summers@vertigo-designs.com>",
 ]
 edition = "2018"
 description = "A Network Abstraction Layer (NAL) for Embedded Systems"

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -21,8 +21,8 @@ pub enum AddrType {
 /// an ip address from a hostname, or a hostname from an ip address. This means
 /// that it only deals in host address records `A` (IPv4) and `AAAA` (IPv6).
 ///
-/// [`TcpStack`]: trait.TcpStack.html
-/// [`UdpStack`]: trait.UdpStack.html
+/// [`TcpStack`]: crate::trait@TcpStack
+/// [`UdpStack`]: crate::trait@UdpStack
 /// [`ToSocketAddrs`]:
 /// https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html
 pub trait Dns {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub trait TcpClient {
 	/// `&buffer[0..n]`, or an error.
 	fn read_with<F>(&self, socket: &mut Self::TcpSocket, f: F) -> nb::Result<usize, Self::Error>
     where
-        F: FnOnce(& mut [u8]) -> usize;
+        F: FnOnce(&[u8], Option<&[u8]>) -> usize;
 
 	/// Close an existing TCP socket.
 	fn close(&self, socket: Self::TcpSocket) -> Result<(), Self::Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,10 +58,10 @@ pub trait TcpClient {
 		buffer: &mut [u8],
 	) -> nb::Result<usize, Self::Error>;
 
-	/// Read from the stream. Returns `Ok(n)`, which means `n` bytes of
+	/// Receive from the stream. Returns `Ok(n)`, which means `n` bytes of
 	/// data have been received and they have been placed in
 	/// `&buffer[0..n]`, or an error.
-	fn read_with<F>(&self, socket: &mut Self::TcpSocket, f: F) -> nb::Result<usize, Self::Error>
+	fn receive_with<F>(&self, socket: &mut Self::TcpSocket, f: F) -> nb::Result<usize, Self::Error>
     where
         F: FnOnce(&[u8], Option<&[u8]>) -> usize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub trait TcpClient {
 	/// `&buffer[0..n]`, or an error.
 	fn read_with<F>(&self, socket: &mut Self::TcpSocket, f: F) -> nb::Result<usize, Self::Error>
     where
-        F: Fn(&[u8], Option<&[u8]>) -> usize;
+        F: FnOnce(&[u8], Option<&[u8]>) -> usize;
 
 	/// Close an existing TCP socket.
 	fn close(&self, socket: Self::TcpSocket) -> Result<(), Self::Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub trait TcpClient {
 	/// `&buffer[0..n]`, or an error.
 	fn read_with<F>(&self, socket: &mut Self::TcpSocket, f: F) -> nb::Result<usize, Self::Error>
     where
-        F: Fn(&[u8], Option<&[u8]>) -> usize;
+        F: FnMut(&[u8], Option<&[u8]>) -> usize;
 
 	/// Close an existing TCP socket.
 	fn close(&self, socket: Self::TcpSocket) -> Result<(), Self::Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub trait TcpClient {
 	/// `&buffer[0..n]`, or an error.
 	fn read_with<F>(&self, socket: &mut Self::TcpSocket, f: F) -> nb::Result<usize, Self::Error>
     where
-        F: FnOnce(&[u8], Option<&[u8]>) -> usize;
+        F: Fn(&[u8], Option<&[u8]>) -> usize;
 
 	/// Close an existing TCP socket.
 	fn close(&self, socket: Self::TcpSocket) -> Result<(), Self::Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub trait TcpClient {
 	/// `&buffer[0..n]`, or an error.
 	fn read_with<F>(&self, socket: &mut Self::TcpSocket, f: F) -> nb::Result<usize, Self::Error>
     where
-        F: FnMut(&[u8], Option<&[u8]>) -> usize;
+        F: Fn(&[u8], Option<&[u8]>) -> usize;
 
 	/// Close an existing TCP socket.
 	fn close(&self, socket: Self::TcpSocket) -> Result<(), Self::Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,13 @@ pub trait TcpClient {
 		buffer: &mut [u8],
 	) -> nb::Result<usize, Self::Error>;
 
+	/// Read from the stream. Returns `Ok(n)`, which means `n` bytes of
+	/// data have been received and they have been placed in
+	/// `&buffer[0..n]`, or an error.
+	fn read_with<F>(&self, socket: &mut Self::TcpSocket, f: F) -> nb::Result<usize, Self::Error>
+    where
+        F: FnOnce(& mut [u8]) -> usize;
+
 	/// Close an existing TCP socket.
 	fn close(&self, socket: Self::TcpSocket) -> Result<(), Self::Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,9 @@ pub trait TcpClient {
 	/// Check if this socket is connected
 	fn is_connected(&self, socket: &Self::TcpSocket) -> Result<bool, Self::Error>;
 
-	/// Write to the stream. Returns the number of bytes written is returned
-	/// (which may be less than `buffer.len()`), or an error.
+	/// Write to the stream.
+	///
+	/// Returns the number of bytes written (which may be less than `buffer.len()`) or an error.
 	fn send(&self, socket: &mut Self::TcpSocket, buffer: &[u8]) -> nb::Result<usize, Self::Error>;
 
 	/// Receive data from the stream.
@@ -66,9 +67,9 @@ pub trait TcpClient {
 pub trait TcpServer: TcpClient {
 	/// Create a new TCP socket and bind it to the specified local port.
 	///
-	///Returns `Ok(socket)` when a new socket is successfully created and bound to the specified
-	///local port. Otherwise, an `Err(e)` variant is returned.
-	fn bind(&self, local_port: u16) -> Result<Self::TcpSocket, Self::Error>;
+	/// Returns `Ok` when a socket is successfully bound to the specified local port. Otherwise, an
+	/// `Err(e)` variant is returned.
+	fn bind(&self, socket: &mut Self::TcpSocket, local_port: u16) -> Result<(), Self::Error>;
 
 	/// Begin listening for connection requests on a previously-bound socket.
 	///
@@ -94,10 +95,13 @@ pub trait UdpClient {
 	/// The type returned when we have an error
 	type Error: core::fmt::Debug;
 
-	/// Open a UDP socket with a dynamically selected port.
+	/// Allocate a socket for further use.
+	fn socket(&self) -> Result<Self::UdpSocket, Self::Error>;
+
+	/// Connect a UDP socket with a peer using a dynamically selected port.
 	///
 	/// Selects a port number automatically and initializes for read/writing.
-	fn connect(&self, remote: SocketAddr) -> Result<Self::UdpSocket, Self::Error>;
+	fn connect(&self, socket: &mut Self::UdpSocket, remote: SocketAddr) -> Result<(), Self::Error>;
 
 	/// Send a datagram to the remote host.
 	///
@@ -124,10 +128,8 @@ pub trait UdpClient {
 /// This trait is implemented by UDP/IP stacks.  It provides the ability to
 /// listen for packets on a specified port and send replies.
 pub trait UdpServer: UdpClient {
-	/// Open a new UDP socket with a specified port
-	///
-	/// Opens a new socket with the specified port number to the given address.
-	fn bind(&self, local_port: u16) -> Result<Self::UdpSocket, Self::Error>;
+	/// Bind a UDP socket with a specified port
+	fn bind(&self, socket: &mut Self::UdpSocket, local_port: u16) -> Result<(), Self::Error>;
 
 	/// Send a packet to a remote host/port.
 	fn send_to(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,10 @@ pub trait TcpServer: TcpClient {
 	///
 	/// Returns `Ok(connection)` if a new connection was created. If no pending connections are
 	/// available, this function should return [`nb::Error::WouldBlock`].
-	fn accept(&self, socket: &mut Self::TcpSocket) -> nb::Result<Self::TcpSocket, Self::Error>;
+	fn accept(
+		&self,
+		socket: &mut Self::TcpSocket,
+	) -> nb::Result<(Self::TcpSocket, SocketAddr), Self::Error>;
 }
 
 /// This trait is implemented by UDP/IP stacks. You could, for example, have

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub use dns::{AddrType, Dns};
 pub use no_std_net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 /// This trait is implemented by TCP/IP stacks. You could, for example, have an implementation
-/// which knows how to send AT commands to an ESP8266 WiFi module. You could have another implemenation
+/// which knows how to send AT commands to an ESP8266 WiFi module. You could have another implementation
 /// which knows how to driver the Rust Standard Library's `std::net` module. Given this trait, you can how
 /// write a portable HTTP client which can work with either implementation.
 pub trait TcpStack {
@@ -56,7 +56,7 @@ pub trait TcpStack {
 
 /// This trait is implemented by UDP/IP stacks. You could, for example, have
 /// an implementation which knows how to send AT commands to an ESP8266 WiFi
-/// module. You could have another implemenation which knows how to driver the
+/// module. You could have another implementation which knows how to driver the
 /// Rust Standard Library's `std::net` module. Given this trait, you can how
 /// write a portable CoAP client which can work with either implementation.
 pub trait UdpClient {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,11 +65,19 @@ pub trait UdpStack {
 	/// The type returned when we have an error
 	type Error: core::fmt::Debug;
 
-	/// Open a local port on a new UDP socket to the given address and port.
+	/// Open a UDP socket with a dynamically selected port.
+	///
+	/// Selects a port number automatically and opens a UDP socket to the given
+	/// address. UDP is connectionless, so unlike `TcpStack` no `connect()` is
+	/// required.
+	fn open(&self, remote: SocketAddr, mode: Mode) -> Result<Self::UdpSocket, Self::Error>;
+
+	/// Open a new UDP socket with a specified port
+	///
+	/// Opens a new socket with the specified port number to the given address.
 	/// UDP is connectionless, so unlike `TcpStack` no `connect()` is required.
-	fn open(
+	fn bind(
 		&self,
-		local_port: u16,
 		remote: SocketAddr,
 	) -> Result<Self::UdpSocket, Self::Error>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,21 +65,16 @@ pub trait UdpStack {
 	/// The type returned when we have an error
 	type Error: core::fmt::Debug;
 
-	/// Create a new socket
-	///
-	/// Allocates a socket for use as a client or a server.
-	fn socket(&self) -> Result<Self::UdpSocket, Self::Error>;
-
 	/// Open a UDP socket with a dynamically selected port.
 	///
 	/// Selects a port number automatically and initializes for read/writing.
-	fn connect(&self, socket: &mut Self::UdpSocket, remote: SocketAddr) -> Result<(), Self::Error>;
+	fn connect(&self, remote: SocketAddr) -> Result<Self::UdpSocket, Self::Error>;
 
 	/// Send a datagram to the remote host.
 	///
 	/// The remote host used is either the one specified in `UdpStack::connect`
 	/// or the last one used in `UdpServerStack::write_to`.
-	fn write(&self, socket: &mut Self::UdpSocket, buffer: &[u8]) -> nb::Result<(), Self::Error>;
+	fn send(&self, socket: &mut Self::UdpSocket, buffer: &[u8]) -> nb::Result<(), Self::Error>;
 
 	/// Read a datagram the remote host has sent to us.
 	///
@@ -88,7 +83,7 @@ pub trait UdpStack {
 	/// If a packet has not been received when called, then
 	/// [`nb::Error::WouldBlock`](https://docs.rs/nb/1.0.0/nb/enum.Error.html#variant.WouldBlock)
 	/// should be returned.
-	fn read(
+	fn receive(
 		&self,
 		socket: &mut Self::UdpSocket,
 		buffer: &mut [u8],
@@ -104,10 +99,10 @@ pub trait UdpServerStack: UdpStack {
 	/// Open a new UDP socket with a specified port
 	///
 	/// Opens a new socket with the specified port number to the given address.
-	fn bind(&self, socket: &mut Self::UdpSocket, local_port: u16) -> Result<(), Self::Error>;
+	fn bind(&self, local_port: u16) -> Result<Self::UdpSocket, Self::Error>;
 
 	/// Send a packet to a remote host/port.
-	fn write_to(
+	fn send_to(
 		&self,
 		socket: &mut Self::UdpSocket,
 		remote: SocketAddr,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,13 @@ pub trait TcpStack {
 	/// (which may be less than `buffer.len()`), or an error.
 	fn write(&self, socket: &mut Self::TcpSocket, buffer: &[u8]) -> nb::Result<usize, Self::Error>;
 
-	/// Read from the stream. Returns `Ok(n)`, which means `n` bytes of
-	/// data have been received and they have been placed in
-	/// `&buffer[0..n]`, or an error.
+	/// Read from the stream.
+	///
+	/// Returns `Ok(n)`, which means `n` bytes of data have been received and
+	/// they have been placed in `&buffer[0..n]`, or an error. If a packet has
+	/// not been received when called, then
+	/// [`nb::Error::WouldBlock`](https://docs.rs/nb/1.0.0/nb/enum.Error.html#variant.WouldBlock)
+	/// should be returned.
 	fn read(
 		&self,
 		socket: &mut Self::TcpSocket,
@@ -78,9 +82,13 @@ pub trait UdpStack {
 	/// Send a datagram to the remote host.
 	fn write(&self, socket: &mut Self::UdpSocket, buffer: &[u8]) -> nb::Result<(), Self::Error>;
 
-	/// Read a datagram the remote host has sent to us. Returns `Ok(n)`, which
-	/// means a datagram of size `n` has been received and it has been placed
-	/// in `&buffer[0..n]`, or an error.
+	/// Read a datagram the remote host has sent to us.
+	///
+	/// Returns `Ok(n)`, which means a datagram of size `n` has been received
+	/// and it has been placed in `&buffer[0..n]`, or an error. If a packet has
+	/// not been received when called, then
+	/// [`nb::Error::WouldBlock`](https://docs.rs/nb/1.0.0/nb/enum.Error.html#variant.WouldBlock)
+	/// should be returned.
 	fn read(
 		&self,
 		socket: &mut Self::UdpSocket,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub trait TcpStack {
 /// module. You could have another implemenation which knows how to driver the
 /// Rust Standard Library's `std::net` module. Given this trait, you can how
 /// write a portable CoAP client which can work with either implementation.
-pub trait UdpStack {
+pub trait UdpClient {
 	/// The type returned when we create a new UDP socket
 	type UdpSocket;
 	/// The type returned when we have an error
@@ -95,7 +95,7 @@ pub trait UdpStack {
 
 /// This trait is implemented by UDP/IP stacks.  It provides the ability to
 /// listen for packets on a specified port and send replies.
-pub trait UdpServerStack: UdpStack {
+pub trait UdpServer: UdpClient {
 	/// Open a new UDP socket with a specified port
 	///
 	/// Opens a new socket with the specified port number to the given address.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,7 @@ pub trait TcpStack {
 	///
 	/// Returns `Ok(n)`, which means `n` bytes of data have been received and
 	/// they have been placed in `&buffer[0..n]`, or an error. If a packet has
-	/// not been received when called, then
-	/// [`nb::Error::WouldBlock`](https://docs.rs/nb/1.0.0/nb/enum.Error.html#variant.WouldBlock)
+	/// not been received when called, then [`nb::Error::WouldBlock`]
 	/// should be returned.
 	fn read(
 		&self,
@@ -80,8 +79,7 @@ pub trait UdpClient {
 	///
 	/// Returns `Ok((n, remote))`, which means a datagram of size `n` has been
 	/// received from `remote` and been placed in `&buffer[0..n]`, or an error.
-	/// If a packet has not been received when called, then
-	/// [`nb::Error::WouldBlock`](https://docs.rs/nb/1.0.0/nb/enum.Error.html#variant.WouldBlock)
+	/// If a packet has not been received when called, then [`nb::Error::WouldBlock`]
 	/// should be returned.
 	fn receive(
 		&self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,6 @@ pub use dns::{AddrType, Dns};
 
 pub use no_std_net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
-/// Whether a socket should block when a read/write can't be performed, or return early.
-pub enum Mode {
-	/// The function call will wait as long as necessary to complete the operation
-	Blocking,
-	/// The function call will not wait at all to complete the operation, and only do what it can.
-	NonBlocking,
-	/// The function call will wait only up the given number of milliseconds to complete the operation.
-	Timeout(u16),
-}
-
 /// This trait is implemented by TCP/IP stacks. You could, for example, have an implementation
 /// which knows how to send AT commands to an ESP8266 WiFi module. You could have another implemenation
 /// which knows how to driver the Rust Standard Library's `std::net` module. Given this trait, you can how
@@ -31,7 +21,7 @@ pub trait TcpStack {
 	type Error: core::fmt::Debug;
 
 	/// Open a new TCP socket. The socket starts in the unconnected state.
-	fn open(&self, mode: Mode) -> Result<Self::TcpSocket, Self::Error>;
+	fn open(&self) -> Result<Self::TcpSocket, Self::Error>;
 
 	/// Connect to the given remote host and port.
 	fn connect(
@@ -77,7 +67,7 @@ pub trait UdpStack {
 
 	/// Open a new UDP socket to the given address and port. UDP is connectionless,
 	/// so unlike `TcpStack` no `connect()` is required.
-	fn open(&self, remote: SocketAddr, mode: Mode) -> Result<Self::UdpSocket, Self::Error>;
+	fn open(&self, remote: SocketAddr) -> Result<Self::UdpSocket, Self::Error>;
 
 	/// Send a datagram to the remote host.
 	fn write(&self, socket: &mut Self::UdpSocket, buffer: &[u8]) -> nb::Result<(), Self::Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,9 +65,13 @@ pub trait UdpStack {
 	/// The type returned when we have an error
 	type Error: core::fmt::Debug;
 
-	/// Open a new UDP socket to the given address and port. UDP is connectionless,
-	/// so unlike `TcpStack` no `connect()` is required.
-	fn open(&self, remote: SocketAddr) -> Result<Self::UdpSocket, Self::Error>;
+	/// Open a local port on a new UDP socket to the given address and port.
+	/// UDP is connectionless, so unlike `TcpStack` no `connect()` is required.
+	fn open(
+		&self,
+		local_port: u16,
+		remote: SocketAddr,
+	) -> Result<Self::UdpSocket, Self::Error>;
 
 	/// Send a datagram to the remote host.
 	fn write(&self, socket: &mut Self::UdpSocket, buffer: &[u8]) -> nb::Result<(), Self::Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! # embedded-nal - A Network Abstraction Layer for Embedded Systems
 
+#![doc(html_root_url = "https://docs.rs/embedded-nal/0.2.0")]
 #![no_std]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
@@ -142,5 +143,3 @@ pub trait UdpServer: UdpClient {
 		buffer: &[u8],
 	) -> nb::Result<(), Self::Error>;
 }
-
-// End Of File

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,16 +84,16 @@ pub trait UdpStack {
 
 	/// Read a datagram the remote host has sent to us.
 	///
-	/// Returns `Ok(n)`, which means a datagram of size `n` has been received
-	/// and it has been placed in `&buffer[0..n]`, or an error. If a packet has
-	/// not been received when called, then
+	/// Returns `Ok((n, remote))`, which means a datagram of size `n` has been
+	/// received from `remote` and been placed in `&buffer[0..n]`, or an error.
+	/// If a packet has not been received when called, then
 	/// [`nb::Error::WouldBlock`](https://docs.rs/nb/1.0.0/nb/enum.Error.html#variant.WouldBlock)
 	/// should be returned.
 	fn read(
 		&self,
 		socket: &mut Self::UdpSocket,
 		buffer: &mut [u8],
-	) -> nb::Result<usize, Self::Error>;
+	) -> nb::Result<(usize, SocketAddr), Self::Error>;
 
 	/// Close an existing UDP socket.
 	fn close(&self, socket: Self::UdpSocket) -> Result<(), Self::Error>;


### PR DESCRIPTION
This PR make `factbird-mini-1.0` branch up-to-date with `v0.2.0`.